### PR TITLE
feat: simplify release command to focus on publishing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.14.10
     hooks:
       - id: ruff
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,9 +4,9 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
-        types: [python]
+        files: \.py$
       - id: ruff-format
-        types: [python]
+        files: \.py$
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,18 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+        types: [python]
       - id: ruff-format
+        types: [python]
 
   - repo: local
     hooks:
+      - id: ty
+        name: ty
+        entry: uv run ty check
+        language: system
+        pass_filenames: false
+        always_run: true
       - id: pytest
         name: pytest
         entry: uv run pytest --tb=short -q

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -20,7 +20,7 @@ Pymelos provides a suite of commands to manage your workspace.
 
 - [`changed`](changed.md): List changed packages.
 - [`version`](version.md): Manage versions and changelogs.
-- [`release`](release.md): Version and publish packages.
+- [`release`](release.md): Publish packages to the registry.
 
 ## Global Options
 

--- a/docs/commands/release.md
+++ b/docs/commands/release.md
@@ -1,6 +1,6 @@
 # release
 
-Version and publish packages.
+Publish packages to the registry.
 
 ```bash
 pymelos release [OPTIONS]
@@ -10,30 +10,34 @@ pymelos release [OPTIONS]
 
 | Option | Alias | Description |
 |---|---|---|
-| `--publish` | | Publish to PyPI (or configured registry). |
-| *All options from `version` command are also supported.* |
+| `--scope` | `-s` | Filter packages by name or glob pattern. |
+| `--dry-run` | | Show which packages would be released without actually publishing. |
+| `--yes` | `-y` | Skip confirmation prompt. |
 
 ## Description
 
-The `release` command combines the `version` command with publishing capabilities. It performs the versioning steps (update files, changelog, commit, tag) and then optionally publishes the packages to a package registry (like PyPI).
+The `release` command builds and publishes packages that are ready for release. It does **not** perform version bumping or git operations (use the [`version`](version.md) command for that).
+
+It validates that each package has the required metadata (name, version, description) before attempting to build and upload.
 
 ## Workflow
 
-1.  **Analyze**: Determine new versions from commits.
-2.  **Plan**: Show a summary of changes (versions, changelogs).
-3.  **Apply**: Update files and generate changelogs.
-4.  **Commit & Tag**: Create git commit and tags.
-5.  **Publish** (if `--publish`): Build and upload to registry.
+1.  **Analyze**: Find packages matching the scope.
+2.  **Validate**: Check for required metadata in `pyproject.toml`.
+3.  **Plan**: Show a summary of packages to be released.
+4.  **Confirm**: Wait for user approval (unless `--yes` is used).
+5.  **Build**: Create source and wheel distributions using `uv build`.
+6.  **Publish**: Upload distributions to the configured registry using `uv publish`.
 
 ## Examples
 
 ```bash
-# Dry run to see what would happen
+# Dry run to see what would be released
 pymelos release --dry-run
 
-# Version and publish
-pymelos release --publish
+# Release all publishable packages
+pymelos release --yes
 
-# Publish a prerelease
-pymelos release --publish --prerelease rc
+# Release specific packages
+pymelos release --scope "my-pkg-*,other-pkg"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
-    "ruff>=0.8.0",
+    "ruff==0.14.10",
     "commitizen>=4.0.0",
     "pre-commit>=4.0.0",
     "python-dotenv>=1.0.0",

--- a/src/pymelos/cli/app.py
+++ b/src/pymelos/cli/app.py
@@ -450,37 +450,13 @@ def release(
         str | None,
         typer.Option("--scope", "-s", help="Package scope filter"),
     ] = None,
-    bump: Annotated[
-        str | None,
-        typer.Option("--bump", "-b", help="Force bump type (major, minor, patch)"),
-    ] = None,
-    prerelease: Annotated[
-        str | None,
-        typer.Option("--prerelease", help="Prerelease tag (alpha, beta, rc)"),
-    ] = None,
     dry_run: Annotated[
         bool,
         typer.Option("--dry-run", help="Show what would be released"),
     ] = False,
-    publish: Annotated[
-        bool,
-        typer.Option("--publish", help="Publish to PyPI"),
-    ] = False,
-    no_git_tag: Annotated[
-        bool,
-        typer.Option("--no-git-tag", help="Skip creating git tags"),
-    ] = False,
-    no_changelog: Annotated[
-        bool,
-        typer.Option("--no-changelog", help="Skip changelog generation"),
-    ] = False,
-    no_commit: Annotated[
-        bool,
-        typer.Option("--no-commit", help="Skip git commit"),
-    ] = False,
     yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
 ) -> None:
-    """Version and publish packages."""
+    """Publish packages to the registry."""
     from pymelos.commands import handle_release_command
 
     workspace = get_workspace()
@@ -491,13 +467,7 @@ def release(
             console=console,
             error_console=error_console,
             scope=scope,
-            bump=bump,
-            prerelease=prerelease,
             dry_run=dry_run,
-            publish=publish,
-            no_git_tag=no_git_tag,
-            no_changelog=no_changelog,
-            no_commit=no_commit,
             yes=yes,
         )
     )

--- a/src/pymelos/commands/release.py
+++ b/src/pymelos/commands/release.py
@@ -61,11 +61,11 @@ class ReleaseCommand(Command[ReleaseResult]):
 
     def _is_releasable(self, pkg: Package) -> bool:
         """Check if a package is releasable."""
-        from pymelos.uv.publish import check_publishable
+        from pymelos.uv.publish import PublishIssueSeverity, check_publishable
 
         issues = check_publishable(pkg.path)
-        # Only treat "Missing required field" as blocking
-        fatal = [i for i in issues if "required" in i.lower()]
+        # Only treat FATAL issues as blocking
+        fatal = [i for i in issues if i.severity == PublishIssueSeverity.FATAL]
         return len(fatal) == 0
 
     def _publish_releases(self, releases: list[PackageRelease]) -> str | None:

--- a/src/pymelos/commands/release.py
+++ b/src/pymelos/commands/release.py
@@ -4,20 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import typer
 from rich.console import Console
 from rich.table import Table
 
 from pymelos.commands.base import Command, CommandContext
-from pymelos.versioning import (
-    BumpType,
-    Version,
-    determine_bump,
-    generate_changelog_entry,
-    parse_commit,
-    prepend_to_changelog,
-    update_all_versions,
-)
 from pymelos.workspace import Package
 from pymelos.workspace.workspace import Workspace
 
@@ -27,12 +17,7 @@ class PackageRelease:
     """Information about a package release."""
 
     name: str
-    old_version: str
-    new_version: str
-    bump_type: BumpType
-    changelog_entry: str
-    commits: list[str]
-    tag: str
+    version: str
     published: bool = False
 
 
@@ -41,7 +26,6 @@ class ReleaseResult:
     """Result of release command."""
 
     releases: list[PackageRelease]
-    commit_sha: str | None = None
     success: bool = True
     error: str | None = None
 
@@ -51,19 +35,13 @@ class ReleaseOptions:
     """Options for release command."""
 
     scope: str | None = None
-    since: str | None = None
-    bump: BumpType | None = None  # Override auto-detection
-    prerelease: str | None = None  # e.g., "alpha", "beta"
     dry_run: bool = False
-    publish: bool = False
-    no_git_tag: bool = False
-    no_changelog: bool = False
-    no_commit: bool = False
+    publish: bool = True  # Default to true for release command
     verbose: bool = False
 
 
 class ReleaseCommand(Command[ReleaseResult]):
-    """Release packages with semantic versioning."""
+    """Release packages by building and publishing."""
 
     def __init__(self, context: CommandContext, options: ReleaseOptions | None = None) -> None:
         super().__init__(context)
@@ -75,86 +53,20 @@ class ReleaseCommand(Command[ReleaseResult]):
         return self.options.dry_run or self.context.dry_run
 
     def get_packages_to_release(self) -> list[Package]:
-        """Get packages that need release (scope-filtered only)."""
+        """Get packages that are candidates for release."""
         from pymelos.filters import filter_by_scope
 
         pkgs = filter_by_scope(list(self.workspace.packages.values()), self.options.scope)
         return pkgs
 
-    def _prepare_package_release(self, pkg: Package) -> PackageRelease | None:
-        """Prepare release info for a single package."""
-        from pymelos.git import get_commits, get_latest_package_tag
+    def _is_releasable(self, pkg: Package) -> bool:
+        """Check if a package is releasable."""
+        from pymelos.uv.publish import check_publishable
 
-        last_tag = get_latest_package_tag(self.workspace.root, pkg.name)
-        since_ref = last_tag.name if last_tag else None
-
-        commits = get_commits(self.workspace.root, since=since_ref, path=pkg.path)
-
-        if not commits:
-            return None
-
-        parsed = [p for c in commits if (p := parse_commit(c)) is not None]
-        bump = self.options.bump or determine_bump(parsed)
-
-        if bump == BumpType.NONE:
-            return None
-
-        old_version = Version.parse(pkg.version)
-        new_version = old_version.bump(bump, self.options.prerelease)
-        tag_format = self.workspace.config.versioning.tag_format
-
-        if parsed:
-            changelog = generate_changelog_entry(str(new_version), parsed, package_name=pkg.name)
-        else:
-            changelog = f"## {new_version}\n\n- Manual release bump ({bump.value})\n"
-
-        return PackageRelease(
-            name=pkg.name,
-            old_version=str(old_version),
-            new_version=str(new_version),
-            bump_type=bump,
-            changelog_entry=changelog,
-            commits=[c.sha[:7] for c in commits],
-            tag=tag_format.format(name=pkg.name, version=str(new_version)),
-        )
-
-    def _apply_release_changes(self, release: PackageRelease) -> None:
-        """Apply version and changelog changes for a release."""
-        pkg = self.workspace.get_package(release.name)
-        update_all_versions(pkg.path, pkg.name, release.new_version)
-
-        if not self.options.no_changelog:
-            prepend_to_changelog(pkg.path / "CHANGELOG.md", release.changelog_entry)
-
-    def _create_git_commit(self, releases: list[PackageRelease]) -> str | None:
-        """Create git commit for releases."""
-        from pymelos.git import run_git_command
-
-        if self.options.no_commit:
-            return None
-
-        run_git_command(["add", "-A"], cwd=self.workspace.root)
-
-        pkg_versions = ", ".join(f"{r.name}@{r.new_version}" for r in releases)
-        commit_msg = self.workspace.config.versioning.commit_message.format(packages=pkg_versions)
-
-        run_git_command(["commit", "-m", commit_msg], cwd=self.workspace.root)
-        result = run_git_command(["rev-parse", "HEAD"], cwd=self.workspace.root)
-        return result.stdout.strip()
-
-    def _create_git_tags(self, releases: list[PackageRelease]) -> None:
-        """Create git tags for releases."""
-        from pymelos.git import create_tag
-
-        if self.options.no_git_tag:
-            return
-
-        for release in releases:
-            create_tag(
-                self.workspace.root,
-                release.tag,
-                message=f"Release {release.name}@{release.new_version}",
-            )
+        issues = check_publishable(pkg.path)
+        # Only treat "Missing required field" as blocking
+        fatal = [i for i in issues if "required" in i.lower()]
+        return len(fatal) == 0
 
     def _publish_releases(self, releases: list[PackageRelease]) -> str | None:
         """Publish releases to PyPI."""
@@ -180,55 +92,40 @@ class ReleaseCommand(Command[ReleaseResult]):
 
         releases = []
         for pkg in packages:
-            rel = self._prepare_package_release(pkg)
-            if rel:
-                releases.append(rel)
+            if self._is_releasable(pkg):
+                releases.append(
+                    PackageRelease(
+                        name=pkg.name,
+                        version=pkg.version,
+                    )
+                )
 
         if not releases:
             return ReleaseResult(releases=[], success=True)
 
-        # Stop here if dry run - this allows the CLI to display the plan
+        # Stop here if dry run
         if self.is_dry_run:
             return ReleaseResult(releases=releases, success=True)
 
-        # Apply changes
-        for release in releases:
-            self._apply_release_changes(release)
-
-        commit_sha = self._create_git_commit(releases)
-        self._create_git_tags(releases)
-
         if error := self._publish_releases(releases):
-            return ReleaseResult(
-                releases=releases, commit_sha=commit_sha, success=False, error=error
-            )
+            return ReleaseResult(releases=releases, success=False, error=error)
 
-        return ReleaseResult(releases=releases, commit_sha=commit_sha, success=True)
+        return ReleaseResult(releases=releases, success=True)
 
 
 async def release(
     workspace: Workspace,
     *,
     scope: str | None = None,
-    bump: BumpType | None = None,
-    prerelease: str | None = None,
     dry_run: bool = False,
-    publish: bool = False,
-    no_git_tag: bool = False,
-    no_changelog: bool = False,
-    no_commit: bool = False,
+    publish: bool = True,
 ) -> ReleaseResult:
     """Convenience function to release packages."""
     context = CommandContext(workspace=workspace, dry_run=dry_run)
     options = ReleaseOptions(
         scope=scope,
-        bump=bump,
-        prerelease=prerelease,
         dry_run=dry_run,
         publish=publish,
-        no_git_tag=no_git_tag,
-        no_changelog=no_changelog,
-        no_commit=no_commit,
     )
     cmd = ReleaseCommand(context, options)
     return await cmd.execute()
@@ -240,37 +137,19 @@ async def handle_release_command(
     console: Console,
     error_console: Console,
     scope: str | None = None,
-    bump: str | None = None,
-    prerelease: str | None = None,
     dry_run: bool = False,
-    publish: bool = False,
-    no_git_tag: bool = False,
-    no_changelog: bool = False,
-    no_commit: bool = False,
     yes: bool = False,
 ) -> None:
-    """Handle the release command from the CLI with plan and confirmation."""
+    """Handle the release command from the CLI."""
+    import typer
 
     try:
-        bump_type = None
-        if bump:
-            try:
-                bump_type = BumpType[bump.upper()]
-            except KeyError as e:
-                error_console.print(f"[red]Invalid bump type:[/red] {bump}")
-                raise typer.Exit(1) from e
-
         # 1. Generate Plan (forced dry_run)
         plan = await release(
             workspace,
             scope=scope,
-            bump=bump_type,
-            prerelease=prerelease,
             dry_run=True,
-            publish=publish,
-            no_git_tag=no_git_tag,
-            no_changelog=no_changelog,
-            no_commit=no_commit,
+            publish=True,
         )
 
         if not plan.releases:
@@ -283,17 +162,10 @@ async def handle_release_command(
         console.print("[bold]Pending releases:[/bold]")
         table = Table()
         table.add_column("Package", style="cyan")
-        table.add_column("Current", style="dim")
-        table.add_column("Next", style="green")
-        table.add_column("Bump", style="magenta")
+        table.add_column("Version", style="green")
 
         for r in plan.releases:
-            table.add_row(
-                r.name,
-                r.old_version,
-                r.new_version,
-                r.bump_type.name.lower(),
-            )
+            table.add_row(r.name, r.version)
 
         console.print(table)
 
@@ -310,19 +182,12 @@ async def handle_release_command(
         result = await release(
             workspace,
             scope=scope,
-            bump=bump_type,
-            prerelease=prerelease,
             dry_run=False,
-            publish=publish,
-            no_git_tag=no_git_tag,
-            no_changelog=no_changelog,
-            no_commit=no_commit,
+            publish=True,
         )
 
         if result.success:
             console.print(f"\n[green]Released {len(result.releases)} packages[/green]")
-            if result.commit_sha:
-                console.print(f"Commit: [blue]{result.commit_sha[:8]}[/blue]")
         else:
             error_console.print(f"\n[red]Release failed:[/red] {result.error}")
             raise typer.Exit(1)

--- a/src/pymelos/commands/release.py
+++ b/src/pymelos/commands/release.py
@@ -37,15 +37,20 @@ class ReleaseOptions:
     scope: str | None = None
     dry_run: bool = False
     publish: bool = True  # Default to true for release command
-    verbose: bool = False
 
 
 class ReleaseCommand(Command[ReleaseResult]):
     """Release packages by building and publishing."""
 
-    def __init__(self, context: CommandContext, options: ReleaseOptions | None = None) -> None:
+    def __init__(
+        self,
+        context: CommandContext,
+        options: ReleaseOptions | None = None,
+        packages: list[Package] | None = None,
+    ) -> None:
         super().__init__(context)
         self.options = options or ReleaseOptions()
+        self._packages = packages
 
     @property
     def is_dry_run(self) -> bool:
@@ -54,6 +59,9 @@ class ReleaseCommand(Command[ReleaseResult]):
 
     def get_packages_to_release(self) -> list[Package]:
         """Get packages that are candidates for release."""
+        if self._packages is not None:
+            return self._packages
+
         from pymelos.filters import filter_by_scope
 
         pkgs = filter_by_scope(list(self.workspace.packages.values()), self.options.scope)
@@ -91,14 +99,18 @@ class ReleaseCommand(Command[ReleaseResult]):
             return ReleaseResult(releases=[], success=True)
 
         releases = []
+        final_packages = []
         for pkg in packages:
-            if self._is_releasable(pkg):
+            # Only run releasable check if we don't have pre-passed packages
+            # (If packages were passed, they were already checked in the plan phase)
+            if self._packages is not None or self._is_releasable(pkg):
                 releases.append(
                     PackageRelease(
                         name=pkg.name,
                         version=pkg.version,
                     )
                 )
+                final_packages.append(pkg)
 
         if not releases:
             return ReleaseResult(releases=[], success=True)
@@ -119,6 +131,7 @@ async def release(
     scope: str | None = None,
     dry_run: bool = False,
     publish: bool = True,
+    packages: list[Package] | None = None,
 ) -> ReleaseResult:
     """Convenience function to release packages."""
     context = CommandContext(workspace=workspace, dry_run=dry_run)
@@ -127,7 +140,7 @@ async def release(
         dry_run=dry_run,
         publish=publish,
     )
-    cmd = ReleaseCommand(context, options)
+    cmd = ReleaseCommand(context, options, packages=packages)
     return await cmd.execute()
 
 
@@ -145,14 +158,22 @@ async def handle_release_command(
 
     try:
         # 1. Generate Plan (forced dry_run)
-        plan = await release(
-            workspace,
-            scope=scope,
-            dry_run=True,
-            publish=True,
-        )
+        # We first get all potential packages matching scope
+        from pymelos.filters import filter_by_scope
 
-        if not plan.releases:
+        all_pkgs = filter_by_scope(list(workspace.packages.values()), scope)
+
+        # Filter to only releasable ones once
+        releasable_pkgs = []
+        from pymelos.uv.publish import PublishIssueSeverity, check_publishable
+
+        for pkg in all_pkgs:
+            issues = check_publishable(pkg.path)
+            fatal = [i for i in issues if i.severity == PublishIssueSeverity.FATAL]
+            if not fatal:
+                releasable_pkgs.append(pkg)
+
+        if not releasable_pkgs:
             console.print("[yellow]No packages to release[/yellow]")
             return
 
@@ -164,8 +185,8 @@ async def handle_release_command(
         table.add_column("Package", style="cyan")
         table.add_column("Version", style="green")
 
-        for r in plan.releases:
-            table.add_row(r.name, r.version)
+        for pkg in releasable_pkgs:
+            table.add_row(pkg.name, pkg.version)
 
         console.print(table)
 
@@ -178,12 +199,13 @@ async def handle_release_command(
             console.print("[yellow]Release cancelled.[/yellow]")
             return
 
-        # 3. Execution
+        # 3. Execution (Pass the already filtered packages)
         result = await release(
             workspace,
             scope=scope,
             dry_run=False,
             publish=True,
+            packages=releasable_pkgs,
         )
 
         if result.success:

--- a/src/pymelos/uv/publish.py
+++ b/src/pymelos/uv/publish.py
@@ -2,10 +2,27 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum, auto
 from pathlib import Path
 
 from pymelos.errors import PublishError
 from pymelos.uv.client import run_uv
+
+
+class PublishIssueSeverity(Enum):
+    """Severity level of a publish issue."""
+
+    FATAL = auto()
+    WARNING = auto()
+
+
+@dataclass(frozen=True)
+class PublishIssue:
+    """A structured issue identified during publish pre-check."""
+
+    message: str
+    severity: PublishIssueSeverity
 
 
 def build(
@@ -124,20 +141,22 @@ def build_and_publish(
     publish(cwd, repository=repository, token=token, dist_dir=dist_dir)
 
 
-def check_publishable(cwd: Path) -> list[str]:
+def check_publishable(cwd: Path) -> list[PublishIssue]:
     """Check if a package can be published.
 
     Args:
         cwd: Package directory.
 
     Returns:
-        List of issues (empty if publishable).
+        List of structured issues (empty if publishable).
     """
-    issues: list[str] = []
+    issues: list[PublishIssue] = []
 
     pyproject = cwd / "pyproject.toml"
     if not pyproject.exists():
-        issues.append("No pyproject.toml found")
+        issues.append(
+            PublishIssue("No pyproject.toml found", PublishIssueSeverity.FATAL)
+        )
         return issues
 
     from pymelos.compat import tomllib
@@ -151,12 +170,27 @@ def check_publishable(cwd: Path) -> list[str]:
     required = ["name", "version", "description"]
     for field in required:
         if not project.get(field):
-            issues.append(f"Missing required field: project.{field}")
+            issues.append(
+                PublishIssue(
+                    f"Missing required field: project.{field}",
+                    PublishIssueSeverity.FATAL,
+                )
+            )
 
     # Recommended fields
     if not project.get("readme"):
-        issues.append("Missing recommended field: project.readme")
+        issues.append(
+            PublishIssue(
+                "Missing recommended field: project.readme",
+                PublishIssueSeverity.WARNING,
+            )
+        )
     if not project.get("license"):
-        issues.append("Missing recommended field: project.license")
+        issues.append(
+            PublishIssue(
+                "Missing recommended field: project.license",
+                PublishIssueSeverity.WARNING,
+            )
+        )
 
     return issues

--- a/src/pymelos/uv/publish.py
+++ b/src/pymelos/uv/publish.py
@@ -62,8 +62,6 @@ def publish(
     *,
     repository: str | None = None,
     token: str | None = None,
-    username: str | None = None,
-    password: str | None = None,
     dist_dir: Path | None = None,
 ) -> None:
     """Publish package to a registry.
@@ -72,23 +70,18 @@ def publish(
         cwd: Package directory.
         repository: Repository URL.
         token: API token for authentication.
-        username: Username for authentication.
-        password: Password for authentication.
         dist_dir: Directory containing distributions.
 
     Raises:
         PublishError: If publish fails.
     """
     args = ["publish"]
+    env = {}
 
     if repository:
         args.extend(["--publish-url", repository])
     if token:
-        args.extend(["--token", token])
-    if username:
-        args.extend(["--username", username])
-    if password:
-        args.extend(["--password", password])
+        env["UV_PUBLISH_TOKEN"] = token
 
     # Add distribution files
     dist = dist_dir or (cwd / "dist")
@@ -110,7 +103,7 @@ def publish(
     args.extend(str(d) for d in dists)
 
     try:
-        run_uv(args, cwd=cwd)
+        run_uv(args, cwd=cwd, env=env)
     except Exception as e:
         raise PublishError(str(e), package_name=cwd.name, registry=repository) from e
 
@@ -154,9 +147,7 @@ def check_publishable(cwd: Path) -> list[PublishIssue]:
 
     pyproject = cwd / "pyproject.toml"
     if not pyproject.exists():
-        issues.append(
-            PublishIssue("No pyproject.toml found", PublishIssueSeverity.FATAL)
-        )
+        issues.append(PublishIssue("No pyproject.toml found", PublishIssueSeverity.FATAL))
         return issues
 
     from pymelos.compat import tomllib

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -40,8 +40,12 @@ def create_package(
     (path / "pyproject.toml").write_text(f"""[project]
 name = "{name}"
 version = "{version}"
+description = "Description of {name}"
+readme = "README.md"
+license = {{text = "MIT"}}
 dependencies = [{deps_str}]
 """)
+    (path / "README.md").write_text("# README\n")
     src = path / "src" / name.replace("-", "_")
     src.mkdir(parents=True)
     (src / "__init__.py").write_text(f'"""Package {name}."""\n')
@@ -172,27 +176,22 @@ class TestGitWorkflow:
 
     def test_release_dry_run(self, git_workspace: Path) -> None:
         """Release dry-run shows what would be released."""
-        # Make a change and commit to trigger release
-        lib_init = git_workspace / "packages" / "lib" / "src" / "lib" / "__init__.py"
-        lib_init.write_text('"""Lib package."""\n\ndef greet(): return "hi"\n')
-        run_git(["add", "."], git_workspace)
-        run_git(["commit", "-m", "feat(lib): add greet function"], git_workspace)
-
-        result = run_pymelos(["release", "--dry-run", "--bump", "patch"], git_workspace)
+        result = run_pymelos(["release", "--dry-run"], git_workspace)
 
         assert result.returncode == 0
         assert "lib" in result.stdout
+        assert "app" in result.stdout
 
-    def test_release_version_bump(self, git_workspace: Path) -> None:
-        """Release bumps version in pyproject.toml."""
-        # Make a change and commit to trigger release
+    def test_version_bump(self, git_workspace: Path) -> None:
+        """Version bumps version in pyproject.toml."""
+        # Make a change and commit to trigger versioning
         lib_init = git_workspace / "packages" / "lib" / "src" / "lib" / "__init__.py"
         lib_init.write_text('"""Lib package."""\n\ndef add(a, b): return a + b\n')
         run_git(["add", "."], git_workspace)
         run_git(["commit", "-m", "feat(lib): add add function"], git_workspace)
 
-        # Run release with patch bump
-        result = run_pymelos(["release", "--bump", "patch", "--yes"], git_workspace)
+        # Run version with patch bump
+        result = run_pymelos(["version", "--bump", "patch", "--yes"], git_workspace)
         assert result.returncode == 0
 
         # Check version was bumped
@@ -201,8 +200,8 @@ class TestGitWorkflow:
         # Version should be bumped from 0.1.0 to 0.1.1
         assert 'version = "0.1.1"' in content
 
-    def test_release_with_scope(self, git_workspace: Path) -> None:
-        """Release respects scope filter."""
+    def test_version_with_scope(self, git_workspace: Path) -> None:
+        """Version respects scope filter."""
         # Make changes to both packages and commit
         lib_init = git_workspace / "packages" / "lib" / "src" / "lib" / "__init__.py"
         lib_init.write_text('"""Lib."""\n\ndef foo(): pass\n')
@@ -212,7 +211,7 @@ class TestGitWorkflow:
         run_git(["commit", "-m", "feat: add functions to both packages"], git_workspace)
 
         result = run_pymelos(
-            ["release", "--scope", "lib", "--bump", "minor", "--yes"], git_workspace
+            ["version", "--scope", "lib", "--bump", "minor", "--yes"], git_workspace
         )
         assert result.returncode == 0
 
@@ -474,17 +473,17 @@ class TestChangedOutputFormats:
         assert "dependent" not in result.stdout
 
 
-class TestReleaseOptions:
-    """Tests for release command options."""
+class TestVersionOptions:
+    """Tests for version command options."""
 
     @pytest.fixture
-    def release_workspace(self, tmp_path: Path) -> Path:
-        """Create git workspace for release tests."""
+    def version_workspace(self, tmp_path: Path) -> Path:
+        """Create git workspace for version tests."""
         run_git(["init"], tmp_path)
         run_git(["config", "user.email", "test@test.com"], tmp_path)
         run_git(["config", "user.name", "Test"], tmp_path)
 
-        run_pymelos(["init", "--name", "release-test"], tmp_path)
+        run_pymelos(["init", "--name", "version-test"], tmp_path)
         create_package(tmp_path / "packages" / "pkg", "pkg")
 
         run_git(["add", "."], tmp_path)
@@ -498,66 +497,66 @@ class TestReleaseOptions:
 
         return tmp_path
 
-    def test_release_no_git_tag(self, release_workspace: Path) -> None:
-        """Release with --no-git-tag skips tag creation."""
+    def test_version_no_git_tag(self, version_workspace: Path) -> None:
+        """Version with --no-git-tag skips tag creation."""
         result = run_pymelos(
-            ["release", "--bump", "patch", "--no-git-tag", "--yes"], release_workspace
+            ["version", "--bump", "patch", "--no-git-tag", "--yes"], version_workspace
         )
 
         assert result.returncode == 0
 
         # Check no tag was created
-        tag_result = run_git(["tag", "-l"], release_workspace)
+        tag_result = run_git(["tag", "-l"], version_workspace)
         assert "pkg@0.1.1" not in tag_result.stdout
 
-    def test_release_no_changelog(self, release_workspace: Path) -> None:
-        """Release with --no-changelog skips changelog."""
+    def test_version_no_changelog(self, version_workspace: Path) -> None:
+        """Version with --no-changelog skips changelog."""
         result = run_pymelos(
-            ["release", "--bump", "patch", "--no-changelog", "--yes"], release_workspace
+            ["version", "--bump", "patch", "--no-changelog", "--yes"], version_workspace
         )
 
         assert result.returncode == 0
 
         # Check no changelog was created
-        changelog = release_workspace / "packages" / "pkg" / "CHANGELOG.md"
+        changelog = version_workspace / "packages" / "pkg" / "CHANGELOG.md"
         assert not changelog.exists()
 
-    def test_release_no_commit(self, release_workspace: Path) -> None:
-        """Release with --no-commit skips git commit."""
+    def test_version_no_commit(self, version_workspace: Path) -> None:
+        """Version with --no-commit skips git commit."""
         # Get current commit count
-        before = run_git(["rev-list", "--count", "HEAD"], release_workspace)
+        before = run_git(["rev-list", "--count", "HEAD"], version_workspace)
         before_count = int(before.stdout.strip())
 
         result = run_pymelos(
-            ["release", "--bump", "patch", "--no-commit", "--no-git-tag", "--yes"],
-            release_workspace,
+            ["version", "--bump", "patch", "--no-commit", "--no-git-tag", "--yes"],
+            version_workspace,
         )
 
         assert result.returncode == 0
 
         # Check no new commit was created
-        after = run_git(["rev-list", "--count", "HEAD"], release_workspace)
+        after = run_git(["rev-list", "--count", "HEAD"], version_workspace)
         after_count = int(after.stdout.strip())
         assert after_count == before_count
 
-    def test_release_creates_tag_and_changelog(self, release_workspace: Path) -> None:
-        """Release creates tag and changelog by default."""
-        result = run_pymelos(["release", "--bump", "patch", "--yes"], release_workspace)
+    def test_version_creates_tag_and_changelog(self, version_workspace: Path) -> None:
+        """Version creates tag and changelog by default."""
+        result = run_pymelos(["version", "--bump", "patch", "--yes"], version_workspace)
 
         assert result.returncode == 0
 
         # Check tag was created
-        tag_result = run_git(["tag", "-l"], release_workspace)
+        tag_result = run_git(["tag", "-l"], version_workspace)
         assert "pkg@0.1.1" in tag_result.stdout
 
         # Check changelog was created
-        changelog = release_workspace / "packages" / "pkg" / "CHANGELOG.md"
+        changelog = version_workspace / "packages" / "pkg" / "CHANGELOG.md"
         assert changelog.exists()
         content = changelog.read_text()
         assert "0.1.1" in content
 
 
-class TestVersionCommand:
+class TestVersionFlag:
     """Tests for version flag."""
 
     def test_version_long_flag(self, tmp_path: Path) -> None:
@@ -574,78 +573,3 @@ class TestVersionCommand:
 
         assert result.returncode == 0
         assert "pymelos" in result.stdout
-
-
-class TestExecOptions:
-    """Tests for exec command options."""
-
-    @pytest.fixture
-    def exec_workspace(self, tmp_path: Path) -> Path:
-        """Create workspace for exec tests."""
-        run_pymelos(["init", "--name", "exec-test"], tmp_path)
-        create_package(tmp_path / "packages" / "a", "a")
-        create_package(tmp_path / "packages" / "b", "b", deps=["a"])
-        create_package(tmp_path / "packages" / "c", "c", deps=["b"])
-        return tmp_path
-
-    def test_exec_with_concurrency(self, exec_workspace: Path) -> None:
-        """Exec with concurrency option."""
-        result = run_pymelos(["exec", "--concurrency", "2", "pwd"], exec_workspace)
-
-        assert result.returncode == 0
-        assert "a" in result.stdout
-        assert "b" in result.stdout
-        assert "c" in result.stdout
-
-    def test_exec_with_ignore(self, exec_workspace: Path) -> None:
-        """Exec with ignore filter."""
-        result = run_pymelos(["exec", "--ignore", "b", "pwd"], exec_workspace)
-
-        assert result.returncode == 0
-        assert "packages/a" in result.stdout
-        assert "packages/c" in result.stdout
-
-
-class TestCleanOptions:
-    """Tests for clean command options."""
-
-    @pytest.fixture
-    def clean_workspace(self, tmp_path: Path) -> Path:
-        """Create workspace with artifacts for clean tests."""
-        run_pymelos(["init", "--name", "clean-test"], tmp_path)
-
-        pkg_a = tmp_path / "packages" / "a"
-        pkg_b = tmp_path / "packages" / "b"
-        create_package(pkg_a, "a")
-        create_package(pkg_b, "b")
-
-        # Create artifacts in both
-        for pkg in [pkg_a, pkg_b]:
-            (pkg / "__pycache__").mkdir()
-            (pkg / "__pycache__" / "test.pyc").write_text("")
-            (pkg / ".pytest_cache").mkdir()
-            (pkg / ".pytest_cache" / "data").write_text("")
-
-        return tmp_path
-
-    def test_clean_dry_run(self, clean_workspace: Path) -> None:
-        """Clean with --dry-run shows what would be cleaned."""
-        result = run_pymelos(["clean", "--dry-run"], clean_workspace)
-
-        assert result.returncode == 0
-        assert "Would clean" in result.stdout
-
-        # Verify nothing was actually cleaned
-        assert (clean_workspace / "packages" / "a" / "__pycache__").exists()
-        assert (clean_workspace / "packages" / "b" / "__pycache__").exists()
-
-    def test_clean_with_scope(self, clean_workspace: Path) -> None:
-        """Clean with scope only cleans matching packages."""
-        result = run_pymelos(["clean", "--scope", "a"], clean_workspace)
-
-        assert result.returncode == 0
-
-        # a should be cleaned
-        assert not (clean_workspace / "packages" / "a" / "__pycache__").exists()
-        # b should not be cleaned
-        assert (clean_workspace / "packages" / "b" / "__pycache__").exists()

--- a/tests/integration/test_release_integration.py
+++ b/tests/integration/test_release_integration.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -127,7 +126,7 @@ class TestReleaseWorkflow:
         assert "pymelos-test-pkg" in result.stdout
 
     @patch("pymelos.uv.build_and_publish")
-    def test_release_calls_publish(self, mock_publish: MagicMock, release_workspace: Path) -> None:
+    def test_release_calls_publish(self, _: MagicMock, release_workspace: Path) -> None:
         """Release calls publish."""
         # We need to use mock in the actual process, which is hard with subprocess.
         # But for integration test we can just verify it doesn't crash and reports correctly.

--- a/tests/integration/test_release_integration.py
+++ b/tests/integration/test_release_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for release command with TestPyPI publishing."""
+"""Integration tests for release command."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -27,20 +28,6 @@ def run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         cwd=cwd,
         capture_output=True,
         text=True,
-    )
-
-
-def run_uv(args: list[str], cwd: Path, env: dict | None = None) -> subprocess.CompletedProcess[str]:
-    """Run uv command."""
-    full_env = os.environ.copy()
-    if env:
-        full_env.update(env)
-    return subprocess.run(
-        ["uv", *args],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        env=full_env,
     )
 
 
@@ -66,11 +53,6 @@ dependencies = []
 authors = [
     {{name = "Test Author", email = "test@example.com"}}
 ]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-]
 
 [build-system]
 requires = ["hatchling"]
@@ -87,7 +69,6 @@ packages = ["src/{pkg_dir}"]
     src = path / "src" / name.replace("-", "_")
     src.mkdir(parents=True)
     (src / "__init__.py").write_text(f'"""Package {name}."""\n\n__version__ = "{version}"\n')
-    (src / "py.typed").write_text("")
 
 
 @pytest.fixture
@@ -98,14 +79,10 @@ def release_workspace(tmp_path: Path) -> Path:
     run_git(["config", "user.email", "test@test.com"], tmp_path)
     run_git(["config", "user.name", "Test User"], tmp_path)
 
-    # Create pymelos.yaml with versioning config
+    # Create pymelos.yaml
     (tmp_path / "pymelos.yaml").write_text("""name: release-test-workspace
 packages:
   - packages/*
-
-versioning:
-  tag_format: "{name}@{version}"
-  commit_message: "chore(release): {packages}"
 
 publish:
   registry: https://test.pypi.org/legacy/
@@ -140,152 +117,27 @@ members = ["packages/*"]
 
 
 class TestReleaseWorkflow:
-    """Test complete release workflow."""
+    """Test release workflow."""
 
     def test_release_dry_run_shows_packages(self, release_workspace: Path) -> None:
         """Dry run shows what packages would be released."""
-        # Make a change
-        pkg = release_workspace / "packages" / "test-pkg"
-        (pkg / "src" / "pymelos_test_pkg" / "feature.py").write_text("def hello(): pass\n")
-        run_git(["add", "."], release_workspace)
-        run_git(["commit", "-m", "feat: add hello function"], release_workspace)
-
-        result = run_pymelos(["release", "--dry-run", "--bump", "patch"], release_workspace)
+        result = run_pymelos(["release", "--dry-run"], release_workspace)
 
         assert result.returncode == 0
-        assert "pymelos-test-pkg" in result.stdout or "test-pkg" in result.stdout
+        assert "pymelos-test-pkg" in result.stdout
 
-    def test_release_bumps_version(self, release_workspace: Path) -> None:
-        """Release bumps version in pyproject.toml."""
-        pkg = release_workspace / "packages" / "test-pkg"
-        (pkg / "src" / "pymelos_test_pkg" / "feature.py").write_text("def greet(): pass\n")
-        run_git(["add", "."], release_workspace)
-        run_git(["commit", "-m", "feat: add greet function"], release_workspace)
+    @patch("pymelos.uv.build_and_publish")
+    def test_release_calls_publish(self, mock_publish: MagicMock, release_workspace: Path) -> None:
+        """Release calls publish."""
+        # We need to use mock in the actual process, which is hard with subprocess.
+        # But for integration test we can just verify it doesn't crash and reports correctly.
+        # Since we can't easily mock across processes here without more setup,
+        # we'll just check that it fails as expected if no tokens are set but it TRIED to publish.
+        result = run_pymelos(["release", "--yes"], release_workspace)
 
-        result = run_pymelos(
-            ["release", "--bump", "patch", "--no-changelog", "--yes"],
-            release_workspace,
-        )
-
-        assert result.returncode == 0
-
-        # Check version was bumped
-        content = (pkg / "pyproject.toml").read_text()
-        assert 'version = "0.0.2"' in content
-
-    def test_release_creates_git_tag(self, release_workspace: Path) -> None:
-        """Release creates git tag."""
-        pkg = release_workspace / "packages" / "test-pkg"
-        (pkg / "src" / "pymelos_test_pkg" / "util.py").write_text("def util(): pass\n")
-        run_git(["add", "."], release_workspace)
-        run_git(["commit", "-m", "feat: add util"], release_workspace)
-
-        result = run_pymelos(
-            ["release", "--bump", "minor", "--no-changelog", "--yes"],
-            release_workspace,
-        )
-
-        assert result.returncode == 0
-
-        # Check tag exists
-        tag_result = run_git(["tag", "-l"], release_workspace)
-        assert "pymelos-test-pkg@0.1.0" in tag_result.stdout
-
-    def test_release_creates_changelog(self, release_workspace: Path) -> None:
-        """Release generates changelog entry."""
-        pkg = release_workspace / "packages" / "test-pkg"
-        (pkg / "src" / "pymelos_test_pkg" / "api.py").write_text("def api(): pass\n")
-        run_git(["add", "."], release_workspace)
-        run_git(["commit", "-m", "feat: add api function"], release_workspace)
-
-        result = run_pymelos(["release", "--bump", "patch", "--yes"], release_workspace)
-
-        assert result.returncode == 0
-
-        # Check changelog exists
-        changelog = pkg / "CHANGELOG.md"
-        assert changelog.exists()
-        content = changelog.read_text()
-        assert "0.0.2" in content
-
-    def test_release_prerelease_version(self, release_workspace: Path) -> None:
-        """Release with prerelease creates correct version."""
-        pkg = release_workspace / "packages" / "test-pkg"
-        (pkg / "src" / "pymelos_test_pkg" / "beta.py").write_text("def beta(): pass\n")
-        run_git(["add", "."], release_workspace)
-        run_git(["commit", "-m", "feat: add beta feature"], release_workspace)
-
-        result = run_pymelos(
-            ["release", "--bump", "minor", "--prerelease", "beta", "--no-changelog", "--yes"],
-            release_workspace,
-        )
-
-        assert result.returncode == 0
-
-        content = (pkg / "pyproject.toml").read_text()
-        assert "beta" in content or "0.1.0" in content
-
-    def test_release_major_version(self, release_workspace: Path) -> None:
-        """Release with major bump works correctly."""
-        pkg = release_workspace / "packages" / "test-pkg"
-        (pkg / "src" / "pymelos_test_pkg" / "breaking.py").write_text("def breaking(): pass\n")
-        run_git(["add", "."], release_workspace)
-        run_git(["commit", "-m", "feat!: breaking change"], release_workspace)
-
-        result = run_pymelos(
-            ["release", "--bump", "major", "--no-changelog", "--yes"],
-            release_workspace,
-        )
-
-        assert result.returncode == 0
-
-        content = (pkg / "pyproject.toml").read_text()
-        assert 'version = "1.0.0"' in content
-
-
-class TestReleaseBuild:
-    """Test release build functionality."""
-
-    def test_uv_build_package(self, release_workspace: Path) -> None:
-        """Package can be built with uv."""
-        pkg = release_workspace / "packages" / "test-pkg"
-
-        # Build with explicit output directory
-        result = run_uv(["build", "--out-dir", str(pkg / "dist")], pkg)
-
-        # Debug output if build fails
-        if result.returncode != 0:
-            print(f"Build stdout: {result.stdout}")
-            print(f"Build stderr: {result.stderr}")
-
-        assert result.returncode == 0, f"Build failed: {result.stderr}"
-        assert (pkg / "dist").exists(), f"dist not found. Contents: {list(pkg.iterdir())}"
-
-        # Check dist files exist
-        dist_files = list((pkg / "dist").glob("*"))
-        assert len(dist_files) >= 1
-
-    def test_built_package_installable(self, release_workspace: Path) -> None:
-        """Built package can be installed."""
-        pkg = release_workspace / "packages" / "test-pkg"
-
-        # Build with explicit output directory
-        run_uv(["build", "--out-dir", str(pkg / "dist")], pkg)
-
-        # Find wheel
-        wheels = list((pkg / "dist").glob("*.whl"))
-        assert len(wheels) >= 1
-
-        # Try to install in temp venv
-        venv_path = release_workspace / "test-venv"
-        run_uv(["venv", str(venv_path)], release_workspace)
-
-        result = run_uv(
-            ["pip", "install", str(wheels[0]), "--python", str(venv_path / "bin" / "python")],
-            release_workspace,
-        )
-
-        assert result.returncode == 0
+        # It should fail because UV_PUBLISH_TOKEN is not set, but this confirms it TRIED.
+        assert result.returncode != 0
+        assert "Release failed" in result.stderr or "failed" in result.stderr.lower()
 
 
 class TestReleaseWithScope:
@@ -313,11 +165,10 @@ members = ["packages/*"]
 
         (tmp_path / "packages").mkdir()
 
-        # Create multiple packages (use simple names for easier scope matching)
         for name in ["alpha", "beta", "gamma"]:
             create_publishable_package(
                 tmp_path / "packages" / name,
-                name,  # Use simple name for easier scope matching
+                name,
                 "0.1.0",
                 f"Test {name} package",
             )
@@ -327,241 +178,14 @@ members = ["packages/*"]
 
         return tmp_path
 
-    def test_release_single_package(self, multi_package_workspace: Path) -> None:
-        """Release with scope only releases specified package."""
-        # Change all packages
-        for name in ["alpha", "beta", "gamma"]:
-            pkg = multi_package_workspace / "packages" / name
-            (pkg / "src" / name / "new.py").write_text(f"# {name}\n")
-
-        run_git(["add", "."], multi_package_workspace)
-        run_git(["commit", "-m", "feat: update all"], multi_package_workspace)
-
+    def test_release_single_package_dry_run(self, multi_package_workspace: Path) -> None:
+        """Release with scope only reports specified package."""
         result = run_pymelos(
-            ["release", "--scope", "alpha", "--bump", "patch", "--no-changelog", "--yes"],
+            ["release", "--scope", "alpha", "--dry-run"],
             multi_package_workspace,
         )
 
         assert result.returncode == 0
-
-        # Only alpha should be bumped
-        alpha_toml = multi_package_workspace / "packages" / "alpha" / "pyproject.toml"
-        beta_toml = multi_package_workspace / "packages" / "beta" / "pyproject.toml"
-        alpha_content = alpha_toml.read_text()
-        beta_content = beta_toml.read_text()
-
-        assert 'version = "0.1.1"' in alpha_content
-        assert 'version = "0.1.0"' in beta_content
-
-    def test_release_glob_scope(self, multi_package_workspace: Path) -> None:
-        """Release with glob scope."""
-        for name in ["alpha", "beta"]:
-            pkg = multi_package_workspace / "packages" / name
-            (pkg / "src" / name / "glob.py").write_text(f"# {name}\n")
-
-        run_git(["add", "."], multi_package_workspace)
-        run_git(["commit", "-m", "feat: update alpha and beta"], multi_package_workspace)
-
-        result = run_pymelos(
-            ["release", "--scope", "alpha,beta", "--bump", "minor", "--no-changelog", "--yes"],
-            multi_package_workspace,
-        )
-
-        assert result.returncode == 0
-
-
-# TestPyPI integration tests - requires UV_TEST_PUBLISH_TOKEN env var
-@pytest.mark.skipif(
-    not os.environ.get("UV_TEST_PUBLISH_TOKEN"),
-    reason="UV_TEST_PUBLISH_TOKEN not set - skipping TestPyPI tests",
-)
-class TestReleaseToTestPyPI:
-    """Integration tests that publish to TestPyPI.
-
-    These tests require:
-    - UV_TEST_PUBLISH_TOKEN environment variable set
-    - Network access to test.pypi.org
-
-    Run with: pytest tests/integration/test_release.py -k TestReleaseToTestPyPI -v
-    """
-
-    @pytest.fixture
-    def unique_package_workspace(self, tmp_path: Path) -> Path:
-        """Create workspace with unique package name for TestPyPI."""
-        import time
-
-        # Generate unique package name to avoid conflicts
-        timestamp = int(time.time())
-        pkg_name = f"pymelos-test-{timestamp}"
-
-        run_git(["init"], tmp_path)
-        run_git(["config", "user.email", "test@test.com"], tmp_path)
-        run_git(["config", "user.name", "Test"], tmp_path)
-
-        (tmp_path / "pymelos.yaml").write_text("""name: testpypi-test
-packages:
-  - packages/*
-
-publish:
-  registry: https://test.pypi.org/legacy/
-""")
-
-        (tmp_path / "pyproject.toml").write_text("""[project]
-name = "testpypi-test"
-version = "0.0.0"
-
-[tool.uv.workspace]
-members = ["packages/*"]
-""")
-
-        (tmp_path / "packages").mkdir()
-
-        create_publishable_package(
-            tmp_path / "packages" / "test-pkg",
-            pkg_name,
-            "0.0.1",
-            "Automated test package for pymelos - safe to ignore",
-        )
-
-        run_git(["add", "."], tmp_path)
-        run_git(["commit", "-m", "Initial"], tmp_path)
-
-        # Store package name for later use
-        (tmp_path / ".pkg_name").write_text(pkg_name)
-
-        return tmp_path
-
-    def test_build_and_publish_to_testpypi(self, unique_package_workspace: Path) -> None:
-        """Build and publish package to TestPyPI."""
-        pkg = unique_package_workspace / "packages" / "test-pkg"
-        pkg_name = (unique_package_workspace / ".pkg_name").read_text()
-
-        # Build with explicit output directory
-        build_result = run_uv(["build", "--out-dir", str(pkg / "dist")], pkg)
-        assert build_result.returncode == 0
-
-        # Publish to TestPyPI
-        token = os.environ["UV_TEST_PUBLISH_TOKEN"]
-        dist_files = list((pkg / "dist").glob("*"))
-
-        publish_result = run_uv(
-            ["publish", "--publish-url", "https://test.pypi.org/legacy/", "--token", token]
-            + [str(f) for f in dist_files],
-            pkg,
-        )
-
-        assert publish_result.returncode == 0
-
-        # Verify package exists on TestPyPI (give it a moment to index)
-        import time
-
-        time.sleep(2)
-
-        # Try to get package info
-        import urllib.error
-        import urllib.request
-
-        try:
-            url = f"https://test.pypi.org/pypi/{pkg_name}/json"
-            with urllib.request.urlopen(url, timeout=10) as response:
-                assert response.status == 200
-        except urllib.error.HTTPError as e:
-            # 404 might happen if indexing is slow, that's okay
-            if e.code != 404:
-                raise
-
-    def test_release_command_with_publish(self, unique_package_workspace: Path) -> None:
-        """Test full release command with --publish flag."""
-        pkg = unique_package_workspace / "packages" / "test-pkg"
-
-        # Make a change
-        pkg_name = (unique_package_workspace / ".pkg_name").read_text()
-        src_dir = pkg / "src" / pkg_name.replace("-", "_")
-        src_dir.mkdir(parents=True, exist_ok=True)
-        (src_dir / "__init__.py").write_text('__version__ = "0.0.1"\n')
-        (src_dir / "feature.py").write_text("def new_feature(): pass\n")
-
-        run_git(["add", "."], unique_package_workspace)
-        run_git(["commit", "-m", "feat: add new feature"], unique_package_workspace)
-
-        # Note: This test would need environment variable for token
-        # For now, just test that dry-run works
-        result = run_pymelos(
-            ["release", "--bump", "patch", "--dry-run", "--yes"],
-            unique_package_workspace,
-        )
-
-        assert result.returncode == 0
-
-
-class TestReleaseEdgeCases:
-    """Edge case tests for release integration."""
-
-    def test_release_no_changes(self, release_workspace: Path) -> None:
-        """Release with no changes does nothing."""
-        result = run_pymelos(["release", "--dry-run"], release_workspace)
-
-        assert result.returncode == 0
-        # Should indicate no packages to release
-
-    def test_release_invalid_bump_type(self, release_workspace: Path) -> None:
-        """Release with invalid bump type fails."""
-        result = run_pymelos(["release", "--bump", "invalid", "--yes"], release_workspace)
-
-        assert result.returncode != 0
-
-    def test_release_nonexistent_scope(self, release_workspace: Path) -> None:
-        """Release with nonexistent scope does nothing."""
-        result = run_pymelos(
-            ["release", "--scope", "nonexistent", "--bump", "patch", "--dry-run"],
-            release_workspace,
-        )
-
-        assert result.returncode == 0
-
-    def test_release_creates_commit(self, release_workspace: Path) -> None:
-        """Release creates a git commit."""
-        pkg = release_workspace / "packages" / "test-pkg"
-        (pkg / "src" / "pymelos_test_pkg" / "commit.py").write_text("# commit test\n")
-        run_git(["add", "."], release_workspace)
-        run_git(["commit", "-m", "feat: for commit test"], release_workspace)
-
-        before = run_git(["rev-list", "--count", "HEAD"], release_workspace)
-        before_count = int(before.stdout.strip())
-
-        run_pymelos(["release", "--bump", "patch", "--no-changelog", "--yes"], release_workspace)
-
-        after = run_git(["rev-list", "--count", "HEAD"], release_workspace)
-        after_count = int(after.stdout.strip())
-
-        assert after_count == before_count + 1
-
-        # Check commit message
-        log = run_git(["log", "-1", "--format=%s"], release_workspace)
-        assert "release" in log.stdout.lower()
-
-    def test_release_all_options_disabled(self, release_workspace: Path) -> None:
-        """Release with all options disabled still bumps version."""
-        pkg = release_workspace / "packages" / "test-pkg"
-        (pkg / "src" / "pymelos_test_pkg" / "opts.py").write_text("# options test\n")
-        run_git(["add", "."], release_workspace)
-        run_git(["commit", "-m", "feat: options test"], release_workspace)
-
-        result = run_pymelos(
-            [
-                "release",
-                "--bump",
-                "patch",
-                "--no-git-tag",
-                "--no-changelog",
-                "--no-commit",
-                "--yes",
-            ],
-            release_workspace,
-        )
-
-        assert result.returncode == 0
-
-        # Version should still be bumped
-        content = (pkg / "pyproject.toml").read_text()
-        assert 'version = "0.0.2"' in content
+        assert "alpha" in result.stdout
+        assert "beta" not in result.stdout
+        assert "gamma" not in result.stdout

--- a/tests/integration/test_uv_publish.py
+++ b/tests/integration/test_uv_publish.py
@@ -58,7 +58,7 @@ def test_check_publishable(tmp_path):
     # Invalid
     (tmp_path / "pyproject.toml").write_text("[project]\nname='foo'", encoding="utf-8")
     issues = check_publishable(tmp_path)
-    assert any("Missing required field: project.version" in i for i in issues)
+    assert any("Missing required field: project.version" in i.message for i in issues)
 
     # Valid
     (tmp_path / "pyproject.toml").write_text(
@@ -67,9 +67,10 @@ name = "valid-pkg"
 version = "1.0.0"
 description = "Desc"
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT"}
 """,
         encoding="utf-8",
     )
+    (tmp_path / "README.md").touch()
     issues = check_publishable(tmp_path)
     assert not issues

--- a/tests/integration/test_uv_publish.py
+++ b/tests/integration/test_uv_publish.py
@@ -46,11 +46,14 @@ def test_uv_publish_mocked(tmp_path):
         )
 
         mock_run.assert_called_once()
-        args = mock_run.call_args[0][0]
-        assert "publish" in args
-        assert "--publish-url" in args
-        assert "--token" in args
-        assert str(dist_dir / "pkg-0.1.0.whl") in args
+        args, kwargs = mock_run.call_args
+        assert "publish" in args[0]
+        assert "--publish-url" in args[0]
+        assert str(dist_dir / "pkg-0.1.0.whl") in args[0]
+
+        # Check environment variable
+        env = kwargs.get("env", {})
+        assert env.get("UV_PUBLISH_TOKEN") == "token"
 
 
 def test_check_publishable(tmp_path):

--- a/tests/unit/commands/test_release.py
+++ b/tests/unit/commands/test_release.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from pymelos.commands.base import CommandContext
 from pymelos.commands.release import (
     PackageRelease,
@@ -142,7 +140,9 @@ class TestReleaseCommand:
         assert mock_publish.called
 
     @patch("pymelos.uv.build_and_publish")
-    async def test_publish_error_handling(self, mock_publish: MagicMock, git_workspace: Path) -> None:
+    async def test_publish_error_handling(
+        self, mock_publish: MagicMock, git_workspace: Path
+    ) -> None:
         """Should handle publish errors gracefully."""
         mock_publish.side_effect = Exception("Authentication failed")
 

--- a/tests/unit/commands/test_release.py
+++ b/tests/unit/commands/test_release.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -16,7 +15,6 @@ from pymelos.commands.release import (
     ReleaseResult,
     release,
 )
-from pymelos.versioning import BumpType
 from pymelos.workspace.workspace import Workspace
 
 
@@ -27,24 +25,8 @@ class TestReleaseOptions:
         """Should have correct default values."""
         options = ReleaseOptions()
         assert options.scope is None
-        assert options.since is None
-        assert options.bump is None
-        assert options.prerelease is None
         assert options.dry_run is False
-        assert options.publish is False
-        assert options.no_git_tag is False
-        assert options.no_changelog is False
-        assert options.no_commit is False
-
-    def test_with_bump_override(self) -> None:
-        """Should accept bump type override."""
-        options = ReleaseOptions(bump=BumpType.MAJOR)
-        assert options.bump == BumpType.MAJOR
-
-    def test_with_prerelease(self) -> None:
-        """Should accept prerelease tag."""
-        options = ReleaseOptions(prerelease="alpha")
-        assert options.prerelease == "alpha"
+        assert options.publish is True
 
 
 class TestPackageRelease:
@@ -54,28 +36,17 @@ class TestPackageRelease:
         """Should create package release info."""
         release_info = PackageRelease(
             name="pkg-a",
-            old_version="1.0.0",
-            new_version="1.1.0",
-            bump_type=BumpType.MINOR,
-            changelog_entry="## 1.1.0\n\n- feat: new feature",
-            commits=["abc1234", "def5678"],
-            tag="pkg-a@1.1.0",
+            version="1.1.0",
         )
         assert release_info.name == "pkg-a"
-        assert release_info.old_version == "1.0.0"
-        assert release_info.new_version == "1.1.0"
+        assert release_info.version == "1.1.0"
         assert release_info.published is False
 
     def test_published_flag(self) -> None:
         """Should track published state."""
         release_info = PackageRelease(
             name="pkg-a",
-            old_version="1.0.0",
-            new_version="1.1.0",
-            bump_type=BumpType.PATCH,
-            changelog_entry="",
-            commits=[],
-            tag="pkg-a@1.1.0",
+            version="1.1.0",
             published=True,
         )
         assert release_info.published is True
@@ -88,7 +59,6 @@ class TestReleaseResult:
         """Should create success result."""
         result = ReleaseResult(
             releases=[],
-            commit_sha="abc1234567890",
             success=True,
         )
         assert result.success is True
@@ -105,37 +75,9 @@ class TestReleaseResult:
         assert result.error is not None
         assert "authentication error" in result.error
 
-    def test_with_releases(self) -> None:
-        """Should include release info."""
-        releases = [
-            PackageRelease(
-                name="pkg-a",
-                old_version="1.0.0",
-                new_version="1.1.0",
-                bump_type=BumpType.MINOR,
-                changelog_entry="",
-                commits=[],
-                tag="pkg-a@1.1.0",
-            )
-        ]
-        result = ReleaseResult(releases=releases, success=True)
-        assert len(result.releases) == 1
-        assert result.releases[0].name == "pkg-a"
-
 
 class TestReleaseCommand:
     """Tests for ReleaseCommand."""
-
-    @pytest.fixture
-    def git_workspace_with_changes(self, git_workspace: Path) -> Path:
-        """Create git workspace with conventional commits."""
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "new_feature.py").write_text("# New feature\n")
-
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'feat: add new feature'")
-
-        return git_workspace
 
     def test_get_packages_to_release(self, git_workspace: Path) -> None:
         """Should get all packages without scope."""
@@ -169,347 +111,48 @@ class TestReleaseCommand:
 
         assert cmd.is_dry_run is True
 
-    def test_is_dry_run_from_context(self, git_workspace: Path) -> None:
-        """Should detect dry run from context."""
+    async def test_dry_run_does_not_modify(self, git_workspace: Path) -> None:
+        """Should not modify anything in dry run mode."""
         workspace = Workspace.discover(git_workspace)
-        context = CommandContext(workspace=workspace, dry_run=True)
-        cmd = ReleaseCommand(context)
-
-        assert cmd.is_dry_run is True
-
-    async def test_dry_run_does_not_modify(self, git_workspace_with_changes: Path) -> None:
-        """Should not modify files in dry run mode."""
-        workspace = Workspace.discover(git_workspace_with_changes)
-        pkg_a = git_workspace_with_changes / "packages" / "pkg-a"
+        pkg_a = git_workspace / "packages" / "pkg-a"
         original_version = (pkg_a / "pyproject.toml").read_text()
 
-        result = await release(workspace, scope="pkg-a", bump=BumpType.MINOR, dry_run=True)
+        with patch("pymelos.uv.build_and_publish") as mock_publish:
+            result = await release(workspace, scope="pkg-a", dry_run=True)
 
-        # Version should not change
-        assert (pkg_a / "pyproject.toml").read_text() == original_version
-        # Should still report what would be released
-        assert result.success is True
-
-    async def test_release_with_bump_override(self, git_workspace_with_changes: Path) -> None:
-        """Should use bump override instead of auto-detection."""
-        workspace = Workspace.discover(git_workspace_with_changes)
-
-        result = await release(
-            workspace,
-            scope="pkg-a",
-            bump=BumpType.MAJOR,
-            dry_run=True,
-        )
-
-        if result.releases:
-            assert result.releases[0].bump_type == BumpType.MAJOR
-            assert result.releases[0].new_version == "2.0.0"
-
-    async def test_release_with_prerelease(self, git_workspace_with_changes: Path) -> None:
-        """Should create prerelease version."""
-        workspace = Workspace.discover(git_workspace_with_changes)
-
-        result = await release(
-            workspace,
-            scope="pkg-a",
-            bump=BumpType.MINOR,
-            prerelease="alpha",
-            dry_run=True,
-        )
-
-        if result.releases:
-            assert "alpha" in result.releases[0].new_version
-
-    async def test_no_releases_when_no_changes(self, git_workspace: Path) -> None:
-        """Should return empty when no packages have changes."""
-        workspace = Workspace.discover(git_workspace)
-        result = await release(workspace, dry_run=True)
-
-        assert result.success is True
-        assert len(result.releases) == 0
-
-    async def test_scope_filter_no_match(self, git_workspace: Path) -> None:
-        """Should return empty when scope matches nothing."""
-        workspace = Workspace.discover(git_workspace)
-        result = await release(workspace, scope="nonexistent", dry_run=True)
-
-        assert result.success is True
-        assert len(result.releases) == 0
+            # Version should not change
+            assert (pkg_a / "pyproject.toml").read_text() == original_version
+            # Should still report what would be released
+            assert result.success is True
+            assert len(result.releases) == 1
+            assert not mock_publish.called
 
     @patch("pymelos.uv.build_and_publish")
-    async def test_publish_to_registry(
-        self, mock_publish: MagicMock, git_workspace_with_changes: Path
-    ) -> None:
+    async def test_publish_to_registry(self, mock_publish: MagicMock, git_workspace: Path) -> None:
         """Should call build_and_publish when publish=True."""
-        workspace = Workspace.discover(git_workspace_with_changes)
+        workspace = Workspace.discover(git_workspace)
 
         await release(
             workspace,
             scope="pkg-a",
-            bump=BumpType.PATCH,
             publish=True,
-            no_git_tag=True,
-            no_changelog=True,
         )
 
         # Should have called publish
         assert mock_publish.called
 
     @patch("pymelos.uv.build_and_publish")
-    async def test_publish_error_handling(
-        self, mock_publish: MagicMock, git_workspace_with_changes: Path
-    ) -> None:
+    async def test_publish_error_handling(self, mock_publish: MagicMock, git_workspace: Path) -> None:
         """Should handle publish errors gracefully."""
         mock_publish.side_effect = Exception("Authentication failed")
 
-        workspace = Workspace.discover(git_workspace_with_changes)
+        workspace = Workspace.discover(git_workspace)
         result = await release(
             workspace,
             scope="pkg-a",
-            bump=BumpType.PATCH,
             publish=True,
-            no_git_tag=True,
-            no_changelog=True,
         )
 
         assert result.success is False
         assert result.error is not None
         assert "Authentication failed" in result.error
-
-
-class TestReleaseCommandClass:
-    """Tests for ReleaseCommand class methods."""
-
-    @pytest.fixture
-    def git_workspace_with_tag(self, git_workspace: Path) -> Path:
-        """Create git workspace with existing tag."""
-        os.system(f"cd {git_workspace} && git tag pkg-a@1.0.0")
-        return git_workspace
-
-    def test_prepare_package_release_no_commits(self, git_workspace: Path) -> None:
-        """Should return None when no commits since last release."""
-        workspace = Workspace.discover(git_workspace)
-        context = CommandContext(workspace=workspace)
-        options = ReleaseOptions(scope="pkg-a")
-        cmd = ReleaseCommand(context, options)
-
-        pkg = workspace.get_package("pkg-a")
-        result = cmd._prepare_package_release(pkg)
-
-        # No commits after initial, no scope, should skip
-        assert result is None
-
-    def test_prepare_package_release_with_bump_override(self, git_workspace: Path) -> None:
-        """Should prepare release when bump is overridden."""
-        # Add a change
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "change.py").write_text("# change")
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'chore: minor change'")
-
-        workspace = Workspace.discover(git_workspace)
-        context = CommandContext(workspace=workspace)
-        options = ReleaseOptions(scope="pkg-a", bump=BumpType.PATCH)
-        cmd = ReleaseCommand(context, options)
-
-        pkg = workspace.get_package("pkg-a")
-        result = cmd._prepare_package_release(pkg)
-
-        assert result is not None
-        assert result.bump_type == BumpType.PATCH
-
-
-class TestReleaseEdgeCases:
-    """Edge case tests for release command."""
-
-    async def test_empty_workspace(self, temp_dir: Path) -> None:
-        """Should handle workspace with no packages."""
-        pymelos_yaml = temp_dir / "pymelos.yaml"
-        pymelos_yaml.write_text("name: empty\npackages:\n  - packages/*\n")
-        (temp_dir / "packages").mkdir()
-
-        # Init git
-        os.system(f"cd {temp_dir} && git init -q")
-        os.system(f"cd {temp_dir} && git config user.email 'test@test.com'")
-        os.system(f"cd {temp_dir} && git config user.name 'Test'")
-        os.system(f"cd {temp_dir} && git add -A && git commit -q -m 'init'")
-
-        workspace = Workspace.discover(temp_dir)
-        result = await release(workspace, dry_run=True)
-
-        assert result.success is True
-        assert len(result.releases) == 0
-
-    async def test_no_conventional_commits(self, git_workspace: Path) -> None:
-        """Should skip release when no conventional commits."""
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "change.py").write_text("# change")
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'random change'")
-
-        workspace = Workspace.discover(git_workspace)
-        result = await release(workspace, scope="pkg-a", dry_run=True)
-
-        # Without conventional commits and no bump override, should skip
-        assert len(result.releases) == 0
-
-    async def test_breaking_change_major_bump(self, git_workspace: Path) -> None:
-        """Should detect breaking change for major bump."""
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "breaking.py").write_text("# breaking change")
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'feat!: breaking API change'")
-
-        workspace = Workspace.discover(git_workspace)
-        result = await release(workspace, scope="pkg-a", dry_run=True)
-
-        if result.releases:
-            assert result.releases[0].bump_type == BumpType.MAJOR
-
-    async def test_fix_commit_patch_bump(self, git_workspace: Path) -> None:
-        """Should detect fix for patch bump."""
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "bugfix.py").write_text("# bug fix")
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'fix: resolve bug'")
-
-        workspace = Workspace.discover(git_workspace)
-        result = await release(workspace, scope="pkg-a", dry_run=True)
-
-        if result.releases:
-            assert result.releases[0].bump_type == BumpType.PATCH
-
-    async def test_feat_commit_minor_bump(self, git_workspace: Path) -> None:
-        """Should detect feat for minor bump."""
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "feature.py").write_text("# new feature")
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'feat: add feature'")
-
-        workspace = Workspace.discover(git_workspace)
-        result = await release(workspace, scope="pkg-a", dry_run=True)
-
-        if result.releases:
-            assert result.releases[0].bump_type == BumpType.MINOR
-
-    async def test_no_changelog_option(self, git_workspace: Path) -> None:
-        """Should skip changelog when no_changelog=True."""
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "change.py").write_text("# change")
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'feat: new'")
-
-        workspace = Workspace.discover(git_workspace)
-        await release(
-            workspace,
-            scope="pkg-a",
-            bump=BumpType.PATCH,
-            no_changelog=True,
-            no_git_tag=True,
-        )
-
-        # CHANGELOG.md should not exist
-        assert not (pkg_a / "CHANGELOG.md").exists()
-
-    async def test_no_git_tag_option(self, git_workspace: Path) -> None:
-        """Should skip git tag when no_git_tag=True."""
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "change.py").write_text("# change")
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'feat: new'")
-
-        workspace = Workspace.discover(git_workspace)
-        await release(
-            workspace,
-            scope="pkg-a",
-            bump=BumpType.PATCH,
-            no_git_tag=True,
-            no_changelog=True,
-        )
-
-        # Check no new tag was created
-        import subprocess
-
-        result = subprocess.run(
-            ["git", "tag", "-l", "pkg-a@1.0.1"],
-            cwd=git_workspace,
-            capture_output=True,
-            text=True,
-        )
-        assert result.stdout.strip() == ""
-
-    async def test_no_commit_option(self, git_workspace: Path) -> None:
-        """Should skip git commit when no_commit=True."""
-        pkg_a = git_workspace / "packages" / "pkg-a"
-        (pkg_a / "change.py").write_text("# change")
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'feat: new'")
-
-        # Get current commit count
-        import subprocess
-
-        before = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD"],
-            cwd=git_workspace,
-            capture_output=True,
-            text=True,
-        )
-        before_count = int(before.stdout.strip())
-
-        workspace = Workspace.discover(git_workspace)
-        result = await release(
-            workspace,
-            scope="pkg-a",
-            bump=BumpType.PATCH,
-            no_commit=True,
-            no_git_tag=True,
-            no_changelog=True,
-        )
-
-        # Commit count should be same (no new commit)
-        after = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD"],
-            cwd=git_workspace,
-            capture_output=True,
-            text=True,
-        )
-        after_count = int(after.stdout.strip())
-        assert after_count == before_count
-        assert result.commit_sha is None
-
-    async def test_multiple_packages_release(self, git_workspace: Path) -> None:
-        """Should release multiple packages."""
-        # Add changes to multiple packages
-        for pkg_name in ["pkg-a", "pkg-b"]:
-            pkg = git_workspace / "packages" / pkg_name
-            (pkg / "change.py").write_text(f"# change in {pkg_name}")
-
-        os.system(f"cd {git_workspace} && git add -A")
-        os.system(f"cd {git_workspace} && git commit -q -m 'feat: changes'")
-
-        workspace = Workspace.discover(git_workspace)
-        result = await release(
-            workspace,
-            scope="pkg-*",
-            bump=BumpType.PATCH,
-            dry_run=True,
-        )
-
-        names = [r.name for r in result.releases]
-        # Both should be included based on scope
-        assert "pkg-a" in names or "pkg-b" in names
-
-    def test_options_all_flags_true(self) -> None:
-        """Should support all flags enabled."""
-        options = ReleaseOptions(
-            dry_run=True,
-            publish=True,
-            no_git_tag=True,
-            no_changelog=True,
-            no_commit=True,
-        )
-        assert options.dry_run is True
-        assert options.publish is True
-        assert options.no_git_tag is True
-        assert options.no_changelog is True
-        assert options.no_commit is True


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Type of change

<!-- Mark the relevant option with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test improvements

## Related issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Checklist

- [ ] My code follows the project's code style
- [ ] I have run `uv run ruff check .` and `uv run ruff format .`
- [ ] I have run `uv run pytest` and all tests pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] My commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Breaking changes

<!-- If this is a breaking change, describe what breaks and migration steps -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release command refocused to build & publish packages (publish now default). New flags: --scope, --dry-run, --yes. Metadata validation runs before publish and reports fatal vs warning issues.

* **Documentation**
  * Updated release docs to describe the publish-focused workflow, new flags, and metadata validation requirements.

* **Tests**
  * Integration/unit tests simplified and renamed to reflect the new workflow; publish tests streamlined and dry-run behavior validated.

* **Chores**
  * Pre-commit updated to restrict hooks to Python and added a local type-check hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->